### PR TITLE
Add support for Python 3.10, drop EOL 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 sudo: true
 
 python:
-    - "3.6"
     - "3.7"
     - "3.8"
     - "3.9"
+    - "3.10"
 
 install:
     - pip install -e .[tests]

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     author='Nicolas Le Manchet',
     author_email='nicolas@lemanchet.fr',
     license='MIT',
+    python_requires=">=3.7",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -34,10 +35,10 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Text Processing :: Markup :: XML'
     ],
     keywords='atom rss json feed feeds syndication parser RFC4287',


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

Python 3.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.1 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

https://endoflife.date/python
