### PR TITLE
Fix docs on parsing Atom XML files vs RSS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,17 @@ Load and parse an Atom XML file:
 .. code:: python
 
     >>> import atoma
-    >>> feed = atoma.parse_rss_file('rss-feed.xml')
+    >>> feed = atoma.parse_atom_feed('atom-feed.xml')
     >>> feed.description
     'The blog relating the daily life of web agency developers'
     >>> len(feed.items)
     5
+
+A small change is needed if you are dealing with an RSS XML file:
+
+.. code:: python
+
+    >>> feed = atoma.parse_rss_feed('rss-feed.xml')
 
 Parsing feeds from the Internet is easy as well:
 


### PR DESCRIPTION
When `parse_rss_feed` is used to parse an Atom feed - as described in the README - the following error is returned:

```
atoma.exceptions.FeedParseError: Cannot process RSS feed version "None"
```

This isn't really saying much to the user, so maybe it'd be interesting to add a hint to the error message, or create a generic `parse` method that identifies the feed type before running the appropriate parser.

For now, I'm just proposing to fix the README.