### PR TITLE
Update code example according to current version.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Load and parse an Atom XML file:
 .. code:: python
 
     >>> import atoma
-    >>> feed = atoma.parse_atom_feed('atom-feed.xml')
+    >>> feed = atoma.parse_atom_file('atom-feed.xml')
     >>> feed.description
     'The blog relating the daily life of web agency developers'
     >>> len(feed.items)


### PR DESCRIPTION
Using atoma.parse_atom_feed() gave me an error, and I saw in the __init__.py file that the function was called atoma.parse_atom_file(). This change to the README should help others get more easily acquainted with the library.